### PR TITLE
:hammer_and_wrench: fix routing confliction

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -87,7 +87,7 @@ const App: React.FC<{}> = () => {
       </Drawer>
 
       <Switch>
-        <Route path="/">
+        <Route exact path="/">
           <Home />
         </Route>
 


### PR DESCRIPTION
指定しないと先頭一致なので一番上に吸い込まれてしまう